### PR TITLE
fix: error building transient menu for Makefiles with target-specific variables

### DIFF
--- a/transient-compile.el
+++ b/transient-compile.el
@@ -735,7 +735,7 @@ inside groups. Also it always places fallback group first."
                     (push (match-string 1 line) targets))))
               (setq skip-target nil))
             (forward-line 1))))
-      (sort targets 'string<))))
+      (seq-uniq (sort targets 'string<)))))
 
 (defun transient-compile-makefile-command (directory target)
   "Format build command for a makefile."


### PR DESCRIPTION
Makefile to reproduce the issue:
```
home-test: MSG = hello world!
home-%:
	@echo "${MSG}"

.PHONY: home-test
```