### PR TITLE
fix: entry point is missing autoload magic comment

### DIFF
--- a/transient-compile.el
+++ b/transient-compile.el
@@ -383,6 +383,7 @@ a break after each Nth group."
   :group 'transient-compile
   :type 'function)
 
+;;;###autoload
 (defun transient-compile ()
   "Open transient menu for compilation.
 


### PR DESCRIPTION
Read more about it in `info "(elisp) Autoload"`.