### PR TITLE
fix: arithmetic error due to target width being too long

### DIFF
--- a/transient-compile.el
+++ b/transient-compile.el
@@ -600,7 +600,8 @@ inside groups. Also it always places fallback group first."
                                 (seq-mapcat 'cdr groups)))))
          ;; how much columns we can fit
          (max-columns
-          (/ (window-body-width) (+ max-width 10))))
+          (max (/ (window-body-width) (+ max-width 10))
+               1))) ; At least 1 column.
     (if (and transient-compile-menu-columns-limit
              (> transient-compile-menu-columns-limit 0))
         (min transient-compile-menu-columns-limit


### PR DESCRIPTION
This integer division could result in 0 when the compilation target had a long name. Transient menus must have at least 1 column.