### PR TITLE
feat: allow transient compile to work over TRAMP connections

### DIFF
--- a/transient-compile.el
+++ b/transient-compile.el
@@ -759,7 +759,7 @@ inside groups. Also it always places fallback group first."
     (let* ((process-environment
             (cons "LC_ALL=C" process-environment))
            (exit-code
-            (call-process-shell-command command nil (current-buffer) nil)))
+            (process-file-shell-command command nil (current-buffer) nil)))
       (buffer-string))))
 
 (defun transient-compile--shell-quote (arg)


### PR DESCRIPTION
`call-process-shell-command` is not aware of TRAMP connections, replacing it for `process-file-shell-command` allows to use `transient-compile` over remote TRAMP connections.

Read more about `process-file-shell-command` in:
```sh
$ info "(elisp) Synchronous Processes"
```