### PR TITLE
fix: incorrect argument error when displaying description of elements

### DIFF
--- a/transient-compile.el
+++ b/transient-compile.el
@@ -1089,7 +1089,7 @@ function that takes directory path and returns t or nil."
                              (transient-compile--tool-property tool :chdir)))
                        `(,target-key
                          ,target-label
-                         (lambda () (interactive)
+                         (lambda () "" (interactive)
                            (unless transient-compile-function
                              (user-error "Missing transient-compile-function."))
                            (let ((transient-compile-target ,target-name)


### PR DESCRIPTION
Transient menus display element descriptions from functions docstrings, this happens when moving the point to different elements in a transient menu.

Functions without docstrings are not propperly handled, leading to a wrong type argument error. The anonymous lambdas, used to build transient-compile dynamic menu, should have an empty string as a docstring.